### PR TITLE
Adding option to disable "PASS" messages for lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ gulp.task('default', function () {
                 // specify your own reporter module
                 // (by-name), or use the built-in one:
                 
-                reporter: 'default'
+                reporter: 'default',
+                errorsOnly: false
                 
                 // ^ there's no need to tell gulp-jslint
                 // to use the default reporter. If there is
@@ -42,6 +43,8 @@ gulp.task('default', function () {
             .pipe(gulp.dest('built'));
 });
 ```
+
+When not specified, the default reporter will write a pass/fail message to the console with every file.  If you only wish to see errors, set the `errorsOnly` property to `true`.  *Note:* The `errorsOnly` property only affects the default reporter.
 
 For a list of directives, see [the official JSLint docs](http://www.jslint.com/lint.html).
 

--- a/gulp.jslint.js
+++ b/gulp.jslint.js
@@ -74,7 +74,9 @@
                                 process.exit(-1);
                             } else {
                                 if (options.reporter === 'default') {
-                                    console.log('[%s] %s', 'PASS'.green, src.path.replace(path.resolve(__dirname) + '/', '').cyan);
+                                    if (!options.errorsOnly) {
+                                        console.log('[%s] %s', 'PASS'.green, src.path.replace(path.resolve(__dirname) + '/', '').cyan);
+                                    }
                                 } else {
                                     try {
                                         // grab the reporter


### PR DESCRIPTION
When one has hundreds of small JavaScript files that get linted, seeing
pages and pages of success messages starts to hide the errors.
Eliminating output when there is no problem makes the lint violations
stand out more prominently.

This option is disabled by default to preserve the original behavior.
