### PR TITLE
Reactivate errorsOnly and use gulp-util in plugin.

### DIFF
--- a/gulp.jslint.js
+++ b/gulp.jslint.js
@@ -10,6 +10,7 @@
     require('colors');
 
     var path = require('path'),
+        gutil = require('gulp-util'),
         evtStr = require('event-stream'),
         jslint = require('jslint'),
         JSLINT = null,
@@ -72,7 +73,9 @@
                                 }
 
                                 // write to screen
-                                console.log(msg);
+                                if (!(evt.pass && options.errorsOnly)) {
+                                    gutil.log(msg);
+                                }
                             };
                         }
 
@@ -87,14 +90,14 @@
                         if (src.jslint.success) {
                             myRet = fn(null, src);
                         } else {
-                            myRet = fn(new Error('gulp-jslint: failed to lint file.'));
+                            myRet = fn(new gutil.PluginError('gulp-jslint', 'failed to lint ' + src.path));
                         }
 
                         return myRet;
                     };
 
                 if (src.isStream()) {
-                    retVal = fn(new Error('gulp-jslint: bad file input.'));
+                    retVal = fn(new gutil.PluginError('gulp-jslint', 'bad input file ' + src.path));
                 } else if (src.isNull()) {
                     retVal = fn(null, src);
                 } else {

--- a/package.json
+++ b/package.json
@@ -6,17 +6,19 @@
   "dependencies": {
     "colors": "^0.6.2",
     "event-stream": "^3.1.5",
+    "gulp-util": "^3.0.0",
     "jslint": "^0.3.4"
   },
   "devDependencies": {
-    "colors": "^0.6.2",
-    "gulp": "^3.6.2",
-    "colortape": "0.0.4",
-    "tape": "^2.13.3",
-    "vinyl": "^0.3.0",
-    "istanbul": "^0.3.0",
     "codeclimate-test-reporter": "0.0.3",
-    "rimraf": "^2.2.8"
+    "colors": "^0.6.2",
+    "colortape": "0.0.4",
+    "gulp": "^3.6.2",
+    "istanbul": "^0.3.0",
+    "rimraf": "^2.2.8",
+    "stripcolorcodes": "^0.1.0",
+    "tape": "^2.13.3",
+    "vinyl": "^0.3.0"
   },
   "scripts": {
     "pretest": "gulp",

--- a/test/test-gulp.jslint.js
+++ b/test/test-gulp.jslint.js
@@ -12,6 +12,7 @@
 
     var fs = require('fs'),
         path = require('path'),
+        strip = require('stripcolorcodes'),
         test = require('tape'),
         Vinyl = require('vinyl'),
         jslint = require('../gulp.jslint.js'),
@@ -168,7 +169,7 @@
     });
 
     test('custom bad reporter (object)', function (t) {
-        t.plan(1);
+        t.plan(4);
 
         var str = jslint({
             reporter: {
@@ -177,7 +178,11 @@
         });
 
         str.on('error', function (err) {
-            t.equal(String(err), 'Error: gulp-jslint: failed to lint file.', 'defaults to default reporter');
+            var message = strip(String(err));
+            t.ok(message.indexOf('Error') > -1);
+            t.ok(message.indexOf('gulp-jslint') > -1);
+            t.ok(message.indexOf('failed to lint') > -1);
+            t.ok(message.indexOf('test/test-nomen.js') > -1);
         });
 
         fs.readFile(path.resolve(__dirname, './test-nomen.js'), function (err, data) {


### PR DESCRIPTION
Reactivate errorsOnly setting lost as a result of #15 (35e257cbf5741cfc729daf9c7ea21819a076be44).
Migrate code from using `Error` objects to `PluginError` objects in **gulp-util**. This allows **gulp** to hide meaningless stack traces.
Migrate code to use `log` in **gulp-util** rather than `console.log`. This allows for a consistent format to plugin console output.
