### PR TITLE
Fix that allows other type of options for reporters

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -29,7 +29,7 @@ const map = require('map-stream'),
       };
 
 module.exports = function (name, options) {
-    options = typeof options === 'object' ? options : {};
+    options = typeof options !== 'undefined' ? options : {};
     let reporter = name || 'default';
 
     // if the report is a function, then it does not need any options


### PR DESCRIPTION
Removed the check for object to a check for undefined, this allows the default reporter to get true passed in